### PR TITLE
Adding code to control network devices monitored

### DIFF
--- a/launch/system_monitor.launch
+++ b/launch/system_monitor.launch
@@ -2,6 +2,7 @@
   <arg name="machine_name" default="$(optenv HOSTNAME localhost)"/>
   <arg name="config_file" default="$(find system_monitor)/config/system_monitor.yaml"/>
   <arg name="output" default="log"/>
+  <arg name="net_dev_regex" default="eth[0-9]+"/>
 
   <group ns="system_monitor/$(arg machine_name)">
     <node name="cpu_monitor" pkg="system_monitor" type="cpu_monitor.py"
@@ -13,7 +14,7 @@
     <node name="ntp_monitor" pkg="system_monitor" type="ntp_monitor.py"
       output="$(arg output)" respawn="true"/>
     <node name="net_monitor" pkg="system_monitor" type="net_monitor.py"
-      output="$(arg output)" respawn="true"/>      
+      output="$(arg output)" respawn="true" args="--dev-regex='$(arg net_dev_regex)'"/>      
   </group>
   
   <rosparam command="load" file="$(arg config_file)"


### PR DESCRIPTION
Command-line arguments to the python code, which allow you to override the normal eth[0-9]+ regex to specify non-traditional or limited sets of network devices to error on.